### PR TITLE
Updated to the latest Group Management Service location

### DIFF
--- a/config/reg/reg-resource-caps.properties
+++ b/config/reg/reg-resource-caps.properties
@@ -1,6 +1,6 @@
 #Global services:
 
 ivo://skao.int/reg = https://src-data-repo.co.uk/reg/capabilities
-ivo://skao.int/gms = https://ska-gms.stfc.ac.uk/gms/capabilities
+ivo://skao.int/gms = https://ws-uv.canfar.net/gms/capabilities
 ivo://skao.int/baldur = https://spsrc27.iaa.csic.es/baldur/capabilities
 ivo://mansrc.int/baldur = https://src-data-repo.co.uk/baldur/capabilities


### PR DESCRIPTION
Updated as required, this is to persist the email suggestion I made when the issue appeared. The GMS service has been moved to a new URL.
